### PR TITLE
Add hotkey script for screenshot to paint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.venv/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Feel free to customize these shortcuts as needed!
 
 ## 🖼️ Snip to Paint
 
-The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
+The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard, and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
 
 > **Note**
 > This helper only works on Windows where the `ms-screenclip:` protocol is available.
@@ -95,12 +95,11 @@ python -m venv venv
 source venv/bin/activate  # On Windows use venv\Scripts\activate
 ```
 
-2. Install the dependencies:
+2. Install the dependency:
 ```bash
 pip install -r requirements.txt
 ```
-
-This installs `pynput` and `Pillow`, which the helper uses for hotkey detection and clipboard access. No Tkinter setup is required.
+This installs `Pillow`, which the helper uses for clipboard access. Hotkey handling relies on built-in Windows APIs so no extra packages are required.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Feel free to customize these shortcuts as needed!
 The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard, and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
 
 > **Note**
-> This helper only works on Windows where the `ms-screenclip:` protocol is available.
+> This helper only works on Windows where the `ms-screenclip:` protocol is available. On other operating systems the script prints a warning and exits.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Feel free to customize these shortcuts as needed!
 
 ## 🖼️ Snip to Paint
 
-`snip_to_paint.py` works on Linux. Press **Win+Shift+S** to start an area screenshot using `gnome-screenshot`. The captured image is copied to the clipboard, a new browser tab with the paint page opens, and the screenshot is pasted automatically.
+`snip_to_paint.py` listens for **Win+Shift+S** on Linux. When pressed, it simulates the standard **Shift+Print Screen** shortcut so you can drag to select an area. Once the screenshot is saved to your `~/Pictures` folder, it copies that file to the clipboard.
 
 ### Setup
 
@@ -96,12 +96,11 @@ source venv/bin/activate
 ```bash
 pip install -r requirements.txt
 ```
-The script depends on `pynput` and requires the `gnome-screenshot` utility to be available on your system.
+The script depends on `pynput`. Make sure either `xclip` or `wl-copy` is installed so the screenshot can be placed on the clipboard.
 
 ### Running
 
 ```bash
 python snip_to_paint.py
 ```
-
-Leave the script running in the background. After you select a screen area, a new browser tab opens with the paint app and the screenshot is pasted.
+Leave the script running in the background. After you select a screen area, the resulting file from your `~/Pictures` folder is copied to the clipboard so you can paste it wherever you need.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Feel free to customize these shortcuts as needed!
 
 The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
 
+> **Note**
+> This helper only works on Windows where the `ms-screenclip:` protocol is available.
+
 ### Setup
 
 1. Create a virtual environment:
@@ -96,6 +99,9 @@ source venv/bin/activate  # On Windows use venv\Scripts\activate
 ```bash
 pip install -r requirements.txt
 ```
+
+This installs `keyboard`, `pyautogui` and `Pillow`, which the helper
+relies on for keyboard hooks, UI automation and clipboard access.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,22 @@ Feel free to customize these shortcuts as needed!
 
 The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
 
+### Setup
+
+1. Create a virtual environment:
+```bash
+python -m venv venv
+source venv/bin/activate  # On Windows use venv\Scripts\activate
+```
+
+2. Install the dependencies:
+```bash
+pip install -r requirements.txt
+```
+
 ### Running
 
 ```bash
-pip install keyboard pyautogui pywin32
 python snip_to_paint.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ source venv/bin/activate  # On Windows use venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-This installs `keyboard`, `pyautogui` and `Pillow`, which the helper
-relies on for keyboard hooks, UI automation and clipboard access.
+This installs `pynput` and `Pillow`, which the helper uses for hotkey detection and clipboard access. No Tkinter setup is required.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -79,3 +79,16 @@ Here are some handy keyboard shortcuts to enhance your painting experience:
 
 Feel free to customize these shortcuts as needed!
 
+
+## 🖼️ Snip to Paint
+
+The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
+
+### Running
+
+```bash
+pip install keyboard pyautogui pywin32
+python snip_to_paint.py
+```
+
+Leave the script running in the background. After you select a screen area, a new browser tab opens with the paint app and the screenshot is pasted.

--- a/README.md
+++ b/README.md
@@ -82,24 +82,21 @@ Feel free to customize these shortcuts as needed!
 
 ## 🖼️ Snip to Paint
 
-The `snip_to_paint.py` script listens for the **Win+Shift+S** shortcut. When triggered it launches the Windows snipping UI, waits for an image to appear on the clipboard, and then opens the paint page in your default browser. The captured image is automatically pasted onto the canvas.
-
-> **Note**
-> This helper only works on Windows where the `ms-screenclip:` protocol is available. On other operating systems the script prints a warning and exits.
+`snip_to_paint.py` works on Linux. Press **Win+Shift+S** to start an area screenshot using `gnome-screenshot`. The captured image is copied to the clipboard, a new browser tab with the paint page opens, and the screenshot is pasted automatically.
 
 ### Setup
 
 1. Create a virtual environment:
 ```bash
 python -m venv venv
-source venv/bin/activate  # On Windows use venv\Scripts\activate
+source venv/bin/activate
 ```
 
 2. Install the dependency:
 ```bash
 pip install -r requirements.txt
 ```
-This installs `Pillow`, which the helper uses for clipboard access. Hotkey handling relies on built-in Windows APIs so no extra packages are required.
+The script depends on `pynput` and requires the `gnome-screenshot` utility to be available on your system.
 
 ### Running
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+keyboard
+pyautogui
+pywin32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Pillow
+pynput

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 keyboard
 pyautogui
-pywin32
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pynput
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-keyboard
-pyautogui
+pynput
 Pillow

--- a/snip_to_paint.py
+++ b/snip_to_paint.py
@@ -3,9 +3,9 @@ import subprocess
 import time
 import webbrowser
 
-import keyboard
-import pyautogui
 from PIL import ImageGrab
+from pynput import keyboard
+from pynput.keyboard import Key, Controller
 
 
 def clipboard_has_image():
@@ -20,7 +20,10 @@ def open_paint_and_paste():
     url = 'file://' + PAINT_FILE.replace(os.sep, '/')
     webbrowser.open_new_tab(url)
     time.sleep(2)
-    pyautogui.hotkey('ctrl', 'v')
+    controller = Controller()
+    with controller.pressed(Key.ctrl):
+        controller.press('v')
+        controller.release('v')
 
 
 def on_hotkey():
@@ -31,5 +34,5 @@ def on_hotkey():
 
 
 if __name__ == '__main__':
-    keyboard.add_hotkey('win+shift+s', on_hotkey)
-    keyboard.wait()
+    with keyboard.GlobalHotKeys({'<cmd>+<shift>+s': on_hotkey}) as h:
+        h.join()

--- a/snip_to_paint.py
+++ b/snip_to_paint.py
@@ -2,37 +2,59 @@ import os
 import subprocess
 import time
 import webbrowser
+import ctypes
+from ctypes import wintypes
 
 from PIL import ImageGrab
-from pynput import keyboard
-from pynput.keyboard import Key, Controller
-
-
-def clipboard_has_image():
-    """Return True if an image is available on the clipboard."""
-    return ImageGrab.grabclipboard() is not None
-
 
 PAINT_FILE = os.path.abspath('index.html')
+
+user32 = ctypes.windll.user32
+
+HOTKEY_ID = 1
+MOD_WIN = 0x0008
+MOD_SHIFT = 0x0004
+VK_S = 0x53
+WM_HOTKEY = 0x0312
+
+
+def send_ctrl_v():
+    user32.keybd_event(0x11, 0, 0, 0)  # Ctrl down
+    user32.keybd_event(0x56, 0, 0, 0)  # V down
+    user32.keybd_event(0x56, 0, 2, 0)  # V up
+    user32.keybd_event(0x11, 0, 2, 0)  # Ctrl up
+
+
+def wait_for_clipboard_image(timeout=10):
+    start = time.time()
+    while time.time() - start < timeout:
+        if ImageGrab.grabclipboard() is not None:
+            return True
+        time.sleep(0.2)
+    return False
 
 
 def open_paint_and_paste():
     url = 'file://' + PAINT_FILE.replace(os.sep, '/')
     webbrowser.open_new_tab(url)
     time.sleep(2)
-    controller = Controller()
-    with controller.pressed(Key.ctrl):
-        controller.press('v')
-        controller.release('v')
+    send_ctrl_v()
 
 
-def on_hotkey():
-    subprocess.Popen(['explorer', 'ms-screenclip:'])
-    while not clipboard_has_image():
-        time.sleep(0.2)
-    open_paint_and_paste()
+def main():
+    if not user32.RegisterHotKey(None, HOTKEY_ID, MOD_WIN | MOD_SHIFT, VK_S):
+        print('Unable to register hotkey. Try running as administrator.')
+        return
+    try:
+        msg = wintypes.MSG()
+        while user32.GetMessageW(ctypes.byref(msg), None, 0, 0) != 0:
+            if msg.message == WM_HOTKEY and msg.wParam == HOTKEY_ID:
+                subprocess.Popen(['explorer', 'ms-screenclip:'])
+                if wait_for_clipboard_image():
+                    open_paint_and_paste()
+    finally:
+        user32.UnregisterHotKey(None, HOTKEY_ID)
 
 
 if __name__ == '__main__':
-    with keyboard.GlobalHotKeys({'<cmd>+<shift>+s': on_hotkey}) as h:
-        h.join()
+    main()

--- a/snip_to_paint.py
+++ b/snip_to_paint.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import subprocess
 import time
 import webbrowser
@@ -6,6 +7,10 @@ import ctypes
 from ctypes import wintypes
 
 from PIL import ImageGrab
+
+if os.name != 'nt':
+    print('snip_to_paint.py only works on Windows.')
+    sys.exit(1)
 
 PAINT_FILE = os.path.abspath('index.html')
 

--- a/snip_to_paint.py
+++ b/snip_to_paint.py
@@ -5,16 +5,12 @@ import webbrowser
 
 import keyboard
 import pyautogui
-import win32clipboard
-import win32con
+from PIL import ImageGrab
 
 
 def clipboard_has_image():
-    win32clipboard.OpenClipboard()
-    try:
-        return win32clipboard.IsClipboardFormatAvailable(win32con.CF_DIB)
-    finally:
-        win32clipboard.CloseClipboard()
+    """Return True if an image is available on the clipboard."""
+    return ImageGrab.grabclipboard() is not None
 
 
 PAINT_FILE = os.path.abspath('index.html')

--- a/snip_to_paint.py
+++ b/snip_to_paint.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import time
+import webbrowser
+
+import keyboard
+import pyautogui
+import win32clipboard
+import win32con
+
+
+def clipboard_has_image():
+    win32clipboard.OpenClipboard()
+    try:
+        return win32clipboard.IsClipboardFormatAvailable(win32con.CF_DIB)
+    finally:
+        win32clipboard.CloseClipboard()
+
+
+PAINT_FILE = os.path.abspath('index.html')
+
+
+def open_paint_and_paste():
+    url = 'file://' + PAINT_FILE.replace(os.sep, '/')
+    webbrowser.open_new_tab(url)
+    time.sleep(2)
+    pyautogui.hotkey('ctrl', 'v')
+
+
+def on_hotkey():
+    subprocess.Popen(['explorer', 'ms-screenclip:'])
+    while not clipboard_has_image():
+        time.sleep(0.2)
+    open_paint_and_paste()
+
+
+if __name__ == '__main__':
+    keyboard.add_hotkey('win+shift+s', on_hotkey)
+    keyboard.wait()


### PR DESCRIPTION
## Summary
- add `snip_to_paint.py` for background screenshot handling
- document how to use `snip_to_paint.py`

## Testing
- `python -m py_compile snip_to_paint.py`

------
https://chatgpt.com/codex/tasks/task_e_684aef1a56fc832694ba5c1b1f2b7ed4